### PR TITLE
ENH: add support for regex lib in FB exports.

### DIFF
--- a/libs/regex/CMakeLists.txt
+++ b/libs/regex/CMakeLists.txt
@@ -30,4 +30,12 @@ set(SOURCES
 
 add_library (boost_regex STATIC ${SOURCES})
 set_target_properties(boost_regex PROPERTIES FOLDER "Libraries")
+add_boost_library(regex)
 
+if (FB_RELEASE)
+    install (TARGETS boost_regex
+        EXPORT FireBreath_Exports
+        DESTINATION bin/\${BUILD_TYPE}
+        COMPONENT FBCORE
+        )
+endif()


### PR DESCRIPTION
Just replicated what was done with other boost libs so boost's regex lib is directly usable by FB projects.
